### PR TITLE
include stdexcept to be able to throw invalid_argument

### DIFF
--- a/LinkSetupFrame.h
+++ b/LinkSetupFrame.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdint>
 #include <string_view> // Don't have std::span in C++17.
+#include <stdexcept>
 
 namespace mobilinkd
 {


### PR DESCRIPTION
just a quicky... tried the compile instructions in the readme, didn't get through due to this missing include.

if you don't mind, i'll try my hands on a cmake build and install next.