### PR TITLE
Cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# cmake build directory
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 project(m17-cxx-demod)
 enable_language(CXX)
 
-#C++11 is a required language feature for this project
+# C++17 is a required language feature for this project
 set(CMAKE_CXX_STANDARD 17)
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(m17-cxx-demod)
+enable_language(CXX)
+
+#C++11 is a required language feature for this project
+set(CMAKE_CXX_STANDARD 17)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE Release)
+    message(STATUS "Build type not specified: defaulting to release.")
+endif()
+
+include(FindPkgConfig)
+include(GNUInstallDirs)
+
+pkg_check_modules(CODEC2 REQUIRED codec2)
+
+add_executable(m17-demod m17-demod.cpp)
+target_link_libraries(m17-demod ${CODEC2_LIBRARIES})
+install(TARGETS m17-demod DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/LinkSetupFrame.h
+++ b/LinkSetupFrame.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdint>
 #include <string_view> // Don't have std::span in C++17.
+#include <stdexcept>
 
 namespace mobilinkd
 {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ running.
 
 This code requires the codec2-devel package be installed.
 
-    make CXXFLAGS="-std=gnu++17 -O3 $(pkg-config --libs codec2)" m17-demod
+    mkdir build
+    cd build
+    cmake ..
+    make
+    sudo make install
 
 ## Running
 


### PR DESCRIPTION
This adds a basic cmake build. Most important advantages:
- will actually check the codec2 dependency (using pkg-config)
- `make install` is now available