### PR TITLE
add missing <limits> include

### DIFF
--- a/include/m17cxx/Correlator.h
+++ b/include/m17cxx/Correlator.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <type_traits>
 #include <tuple>
+#include <limits>
 
 namespace mobilinkd {
 

--- a/include/m17cxx/Util.h
+++ b/include/m17cxx/Util.h
@@ -8,6 +8,7 @@
 #include <array>
 #include <bitset>
 #include <tuple>
+#include <limits>
 
 
 namespace mobilinkd


### PR DESCRIPTION
Had compiler errors stemming from `std::numeric_limits` in both files.

Should be the correct include according to https://en.cppreference.com/w/cpp/types/numeric_limits