### PR TITLE
fix includes:

### DIFF
--- a/tests/SlidingDFTTest.cpp
+++ b/tests/SlidingDFTTest.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <functional>
 
 // make CXXFLAGS="$(pkg-config --cflags gtest) $(pkg-config --libs gtest) -I. -O3 -std=c++17" tests/SlidingDFTTest

--- a/tests/SlidingDFTTest.cpp
+++ b/tests/SlidingDFTTest.cpp
@@ -2,8 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <cstdint>
+#include <functional>
 
 // make CXXFLAGS="$(pkg-config --cflags gtest) $(pkg-config --libs gtest) -I. -O3 -std=c++17" tests/SlidingDFTTest
 


### PR DESCRIPTION
* std::ref should be in `<functional>`
* `cstdint` and `algorithm` seem to be unused / obsoleted by `functional` (at least that's what my IDE says)

Found this while building with tests on Debian Buster. The original worked fine on my Manjaro machine, and with the changes it works on both. Don't ask me why every compiler has their own preferences when it comes to includes...