### PR TITLE
Fix extraction of LSF type bits

### DIFF
--- a/apps/m17-demod.cpp
+++ b/apps/m17-demod.cpp
@@ -154,9 +154,9 @@ bool dump_lsf(std::array<T, N> const& lsf)
     current_packet.clear();
     packet_frame_counter = 0;
 
-    if (!lsf[111]) // LSF type bit 0
+    if (!(lsf[13] & 1)) // LSF type bit 0
     {
-        uint8_t packet_type = (lsf[109] << 1) | lsf[110];
+        uint8_t packet_type = (lsf[13] & 6) >> 1;
 
         switch (packet_type)
         {


### PR DESCRIPTION
GCC's Undefined Behaviour Sanitizer reports the following error when running m17-demod:

```
runtime error: index 111 out of bounds for type 'unsigned char [30]'
```

This occurs because the last portion of `dump_lsf` indexes the `lsf` array by bits, even though the array actually contains bytes. I've corrected the problem here.