### PR TITLE
Free the CODEC2 structure after use

### DIFF
--- a/apps/m17-mod.cpp
+++ b/apps/m17-mod.cpp
@@ -619,6 +619,8 @@ void transmit(queue_t& queue, const lsf_t& lsf)
     auto data = make_data_frame(frame_number | 0x8000, encode(codec2, audio));
     send_audio_frame(lich[lich_segment], data);
     output_eot();
+
+    codec2_destroy(codec2);
 }
 
 #define USE_OLD_MODULATOR


### PR DESCRIPTION
GCC's Address Sanitizer reports memory leaks in m17-mod:

```
==694220==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4480 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358577f03 in codec2_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x18f03)
    #2 0x55dc8faaa071 in operator() /home/argilo/git/m17-cxx-demod/apps/m17-mod.cpp:648
    #3 0x55dc8faab211 in __invoke_impl<void, main(int, char**)::<lambda()> > /usr/include/c++/11/bits/invoke.h:61
    #4 0x55dc8faab1d4 in __invoke<main(int, char**)::<lambda()> > /usr/include/c++/11/bits/invoke.h:96
    #5 0x55dc8faab181 in _M_invoke<0> /usr/include/c++/11/bits/std_thread.h:253
    #6 0x55dc8faab155 in operator() /usr/include/c++/11/bits/std_thread.h:260
    #7 0x55dc8faab139 in _M_run /usr/include/c++/11/bits/std_thread.h:211
    #8 0x7f83583ca2c2  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc2c2)

Indirect leak of 10816 byte(s) in 2 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358577a99 in kiss_fftr_alloc (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x18a99)

Indirect leak of 8720 byte(s) in 2 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f83585739bc in kiss_fft_alloc (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x149bc)

Indirect leak of 1768 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358573a20 in nlp_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x14a20)

Indirect leak of 1684 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358578243 in codec2_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x19243)

Indirect leak of 1280 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358577fc3 in codec2_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x18fc3)

Indirect leak of 1280 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358577fe0 in codec2_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x18fe0)

Indirect leak of 640 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358577f9e in codec2_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x18f9e)

Indirect leak of 640 byte(s) in 1 object(s) allocated from:
    #0 0x7f83594ba867 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8358577f82 in codec2_create (/lib/x86_64-linux-gnu/libcodec2.so.1.0+0x18f82)

SUMMARY: AddressSanitizer: 31308 byte(s) leaked in 11 allocation(s).
```

I've fixed the problem by adding a call to `codec2_destroy` at the end of the `transmit` function.