### PR TITLE
Stream BER diagnostics instead of using snprintf

### DIFF
--- a/apps/m17-demod.cpp
+++ b/apps/m17-demod.cpp
@@ -362,9 +362,7 @@ void diagnostic_callback(bool dcd, FloatType evm, FloatType deviation, FloatType
         }
     
         auto ber = double(prbs.errors()) / double(prbs.bits());
-        char buffer[40];
-        snprintf(buffer, 40, "BER: %-1.6lf (%lu bits)", ber, prbs.bits());
-        std::cerr << buffer;
+        std::cerr << "BER: " << std::fixed << std::setprecision(6) << ber << " (" << prbs.bits() << ")";
     }
     std::cerr << std::flush;
 }


### PR DESCRIPTION
The following warning occurs during compilation, due to a mismatched format specifier:
```
/home/argilo/git/m17-cxx-demod/apps/m17-demod.cpp: In instantiation of ‘void diagnostic_callback(bool, FloatType, FloatType, FloatType, bool, FloatType, int, int, int, int) [with FloatType = float]’:
/home/argilo/git/m17-cxx-demod/apps/m17-demod.cpp:478:22:   required from here
/home/argilo/git/m17-cxx-demod/apps/m17-demod.cpp:366:47: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘uint32_t’ {aka ‘unsigned int’} [-Wformat=]
  366 |         snprintf(buffer, 40, "BER: %-1.6lf (%lu bits)", ber, prbs.bits());
      |                                             ~~^              ~~~~~~~~~~~
      |                                               |                       |
      |                                               long unsigned int       uint32_t {aka unsigned int}
      |                                             %u
```
We can avoid the need for format specifiers, as well as the need for a fixed-length buffer, by using C++ stream output instead (as is done elsewhere in m17-cxx-demod).